### PR TITLE
Check if file index exists

### DIFF
--- a/src/Stackify/Log/Entities/ErrorWrapper.php
+++ b/src/Stackify/Log/Entities/ErrorWrapper.php
@@ -123,7 +123,7 @@ class ErrorWrapper
         }
         foreach ($trace as $item) {
             // check if path starts with $excludePath
-            if (false === strpos($item['file'], $excludePath)) {
+            if (isset($item['file']) && false === strpos($item['file'], $excludePath)) {
                 $filtered[] = $item;
             }
         }


### PR DESCRIPTION
Fix for the error

Error in exception handler: Undefined index: file in /.../vendor/stackify/logger/src/Stackify/Log/Entities/ErrorWrapper.php:126