### PR TITLE
SF-3436: Mask HTTP Authorization header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor
 composer.lock
+.idea
+*.iml

--- a/src/Stackify/Log/Entities/Api/WebRequestDetail.php
+++ b/src/Stackify/Log/Entities/Api/WebRequestDetail.php
@@ -8,6 +8,7 @@ class WebRequestDetail
 {
 
     const HIDDEN_VALUE = 'X-MASKED-X';
+    private static $HIDDEN_HEADERS = array('cookie', 'authorization');
 
     /**
      * @var string
@@ -188,7 +189,7 @@ class WebRequestDetail
             }
         }
         foreach ($headers as $name => $value) {
-            if ('cookie' === strtolower($name)) {
+            if (in_array(strtolower($name), self::$HIDDEN_HEADERS)) {
                 $headers[$name] = self::HIDDEN_VALUE;
             }
         }


### PR DESCRIPTION
Added functionality to mask the HTTP authorization header when sending error information to Stackify.