### PR TITLE
LNX-289 - Remove guzzle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
     "require": {
         "php": ">=5.3.0",
         "psr/log": "~1.0",
-        "guzzlehttp/guzzle": "^6.3",
         "guzzlehttp/psr7": "^1.6",
         "php-http/socket-client": "^2.0",
         "php-http/message": "^1.8"


### PR DESCRIPTION
Guzzle dependency is not being used anywhere in the codebase.

Only the PSR7 dependency is being used for the MessageFactory