### PR TITLE
PHP-4 - Add support for error type to be from the error message

### DIFF
--- a/src/Stackify/Log/Transport/Config/AbstractConfig.php
+++ b/src/Stackify/Log/Transport/Config/AbstractConfig.php
@@ -134,6 +134,12 @@ abstract class AbstractConfig
      * @var boolean
      */
     protected $Debug;
+    /**
+     * Exception Class Blacklist
+     *
+     * @var array
+     */
+    protected $CaptureExceptionClassBlacklist;
 
 
     /**
@@ -170,6 +176,7 @@ abstract class AbstractConfig
         $ds = DIRECTORY_SEPARATOR;
         $this->DebugLogPath = realpath(dirname(__FILE__) . "$ds..$ds..") . $ds . 'debug/log.log';
         $this->Debug = false;
+        $this->CaptureExceptionClassBlacklist = null;
     }
 
     /**
@@ -408,6 +415,17 @@ abstract class AbstractConfig
     {
         $this->Debug = $this->getBoolean($enable, 'Debug');
     }
+    /**
+     * Set capture Exception Class blacklist for ErrorType
+     *
+     * @param array $rawConfig From config
+     *
+     * @return void
+     */
+    public function setCaptureExceptionClassBlacklist($rawConfig = null)
+    {
+        $this->CaptureExceptionClassBlacklist = $this->parseStringToArray($rawConfig, 'CaptureExceptionClassBlacklist');
+    }
 
 
     /**
@@ -598,6 +616,15 @@ abstract class AbstractConfig
     public function getDebug()
     {
         return $this->Debug;
+    }
+    /**
+     * Get capture exception class for error type blacklist
+     *
+     * @return mixed
+     */
+    public function getCaptureExceptionClassBlacklist()
+    {
+        return $this->CaptureExceptionClassBlacklist;
     }
 
     /**

--- a/tests/Log/Entities/ErrorWrapperTest.php
+++ b/tests/Log/Entities/ErrorWrapperTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Stackify\Tests\Log\Entities;
+
+use Stackify\Log\Entities\ErrorWrapper;
+use Stackify\Log\Transport\Config\Agent;
+use Stackify\Tests\Log\Entities\Fixtures\TestException;
+
+class ErrorWrapperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCaptureExceptionBlacklistWithCustomException()
+    {
+        $agentConfig = new Agent();
+        $agentConfig->setCaptureExceptionClassBlacklist([
+            TestException::class
+        ]);
+
+        $message = "Test exception random";
+        $exception = new TestException($message);
+        $errorWrapperObject = new ErrorWrapper($exception, 1, $agentConfig);
+
+        $this->assertSame($message, $errorWrapperObject->getType());
+    }
+
+    public function testEmptyCaptureExceptionBlacklistWithCustomException()
+    {
+        $message = "Test exception random";
+        $exception = new TestException($message);
+        $errorWrapperObject = new ErrorWrapper($exception);
+
+        $this->assertSame(TestException::class, $errorWrapperObject->getType());
+    }
+}

--- a/tests/Log/Entities/Fixtures/TestException.php
+++ b/tests/Log/Entities/Fixtures/TestException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace Stackify\Tests\Log\Entities\Fixtures;
+
+class TestException extends \Exception {
+}


### PR DESCRIPTION
- Add support to consider error message as error type.