### PR TITLE
Fixed bug for Php8 - explode(): Passing null to parameter #2 ($string) of type string is deprecated

### DIFF
--- a/src/Stackify/Log/Entities/Api/WebRequestDetail.php
+++ b/src/Stackify/Log/Entities/Api/WebRequestDetail.php
@@ -329,7 +329,14 @@ class WebRequestDetail
         $https = filter_input(INPUT_SERVER, 'HTTPS');
         $ssl = null !== $https && 'off' !== $https;
         $protocol = $ssl ? 'https' : 'http';
-        list($url,) = explode('?', filter_input(INPUT_SERVER, 'REQUEST_URI'));
+        $inputServerValue = filter_input(INPUT_SERVER, 'REQUEST_URI');
+        if (is_null($inputServerValue)) {
+            $url = '';
+        }
+        else {
+            list($url,) = explode('?', $inputServerValue);
+        }
+
         $serverName = filter_input(INPUT_SERVER, 'SERVER_NAME');
         if ($serverName && $url) {
             return "$protocol://$serverName" . $url;


### PR DESCRIPTION
Deprecated (8192): explode(): Passing null to parameter #2 ($string) of type string is deprecated in [/var/www/html/integrations/vendor/stackify/logger/src/Stackify/Log/Entities/Api/WebRequestDetail.php, line 332]